### PR TITLE
Add a new helper function to create hash table partitions

### DIFF
--- a/etl_tools/initialize_utils/partitioning.sql
+++ b/etl_tools/initialize_utils/partitioning.sql
@@ -29,3 +29,23 @@ $$
 LANGUAGE plpgsql;
 
 
+/** Adds evenly-distributed table partitions by hash (introduced in Postgres 11) to a given table_name and schema_name */
+CREATE OR REPLACE FUNCTION util.create_table_hash_partitions(schema_name TEXT,
+                                                             table_name TEXT,
+                                                             partitions INT)
+    RETURNS VOID AS
+$$
+DECLARE
+    i      INT;
+    target INT;
+BEGIN
+    target := partitions - 1;
+    FOR i IN 0..target
+        LOOP
+            EXECUTE ' CREATE TABLE ' || schema_name || '.' || table_name || '_' || i ||
+                    ' PARTITION OF ' || schema_name || '.' || table_name ||
+                    ' FOR VALUES WITH (MODULUS ' || partitions || ', REMAINDER ' || i || ')';
+
+        END LOOP;
+END ;
+$$ LANGUAGE plpgsql

--- a/etl_tools/initialize_utils/partitioning.sql
+++ b/etl_tools/initialize_utils/partitioning.sql
@@ -48,4 +48,4 @@ BEGIN
 
         END LOOP;
 END ;
-$$ LANGUAGE plpgsql
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
### Objective
The objective of this PR to utilize Postgres 11's native hash partitioning, and to enable easy creation of hash partitions.

There are three main benefits to hash partitioning:

1.  Autovacuum will have maintain several smaller tables rather than one big table
2.  Allows parallel processing of chunked table partitions, especially with using Mara's parallel task executor
3.  Potential improvements for joins between tables partitioned by the same key. This feature was introduced by PG 11's partition-wise joins & partition-wise aggregations (which needs to be first enabled in the conf file or manually SET before taking effect in query planning)

### Example usage:
```
CREATE TABLE foo.bar (  
id TEXT,  
some_col TEXT  
) PARTITION BY HASH (id);

SELECT util.create_table_hash_partitions('foo', 'bar', 10); 
```


`Note: Instead of specifying a number, we can use templating eg. "@Partitions@" which can be a globally-defined variable that matches the number of chunks function in the ETL`

### Potential improvements:  
Allow creation of table partitions on pre-defined separate tablespaces (to store each partition separately).

### References:

1.  [Documentation](https://www.postgresql.org/docs/12/ddl-partitioning.html)
2.  [2nd Quadrant](https://www.2ndquadrant.com/en/blog/partitioning-improvements-pg11/)