### PR TITLE
Fix assert_almost_equal for integer inputs

### DIFF
--- a/etl_tools/initialize_utils/consistency_checks.sql
+++ b/etl_tools/initialize_utils/consistency_checks.sql
@@ -105,7 +105,7 @@ BEGIN
   INTO result1;
   EXECUTE query2
   INTO result2;
-  EXECUTE 'SELECT coalesce( abs((' || result2 || ' - ' || result1 || ') / nullif(' || result1 || ', 0)), 0 ) < ' ||
+  EXECUTE 'SELECT coalesce( abs((' || result2 || ' - ' || result1 || ') ::NUMERIC / nullif(' || result1 || ', 0)), 0 ) < ' ||
           percentage
   INTO succeeded;
   IF NOT succeeded


### PR DESCRIPTION
The joy of integer divisions:

```
postgres=# select 3/2;
 ?column? 
----------
        1
(1 row)

postgres=# select 3.0/2;
      ?column?      
--------------------
 1.5000000000000000
(1 row)

postgres=# select 3/2.0;
      ?column?      
--------------------
 1.5000000000000000
(1 row)
```